### PR TITLE
Added info that should prevent failed builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ If using leveldb scripts, copy your database to a test location (default is `~/d
 ```
 cp -r ~/AppData/Roaming/legends-of-idleon/"Local Storage"/leveldb ~/dev/leveldb
 ```
+### Updating the dev build since the addition of idleon-data as a submodule
+If `idleon-saver/idleon_data/` is empty, make sure to run the following command from your project root:  
+`git submodule update --init --recursive`
 
 ### Running the GUI
 


### PR DESCRIPTION
Merging upstream/main into my repository and running from there left me with errors[^1]. The info added to the README should be enough for someone in a similar spot to get a working build again.

[^1]: Got a FileNotFoundError and was really confused despite Github saying my repository was up to date with upstream/main.

Github Desktop does not have a tool to do this, it has to be through the command line.